### PR TITLE
win_system: return False from a skipped reboot

### DIFF
--- a/salt/modules/win_system.py
+++ b/salt/modules/win_system.py
@@ -173,7 +173,7 @@ def reboot(timeout=5, in_seconds=False, wait_for_reboot=False,  # pylint: disabl
         state intended to be executed
         at the end of a state run (using *order: last*).
 
-    :return: True if successful
+    :return: True if successful (a reboot will occur)
     :rtype: bool
 
     CLI Example:
@@ -263,7 +263,7 @@ def shutdown(message=None, timeout=5, force_close=True, reboot=False,  # pylint:
     timeout = _convert_minutes_seconds(timeout, in_seconds)
 
     if only_on_pending_reboot and not get_pending_reboot():
-        return True
+        return False
 
     if message and not isinstance(message, str):
         message = message.decode('utf-8')


### PR DESCRIPTION
### What does this PR do?
Return False from win_system.reboot, when the reboot wasn't required.
Clarify what the return value represents.

### What issues does this PR fix or reference?
As discussed in #39243.

### Previous Behavior
Return value of True doesn't indicate whether a reboot will occur.

### New Behavior
Return value of True indicates that a reboot will occur.

### Tests written?
No